### PR TITLE
Allow port number to be configured via param, config file

### DIFF
--- a/src/github.com/t3chguy/matrix-static/mxclient/mxclient.go
+++ b/src/github.com/t3chguy/matrix-static/mxclient/mxclient.go
@@ -116,6 +116,7 @@ type Config struct {
 	RefreshToken string `json:"refresh_token"`
 	UserID       string `json:"user_id"`
 	MediaBaseUrl string `json:"media_base_url"`
+	PortNumber   int `json:"port"`
 }
 
 // NewClient returns a Client configured by the config file found at configPath or an error if encountered.


### PR DESCRIPTION
This adds the ability to configure the HTTP port via `-port` as well as in a config file via the `port` option.